### PR TITLE
Replace path.join with urljoin so that URL generation works on Windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const urljoin = require('url-join');
 
 const visit = require('unist-util-visit');
 const Draw = require('./lib/draw');
@@ -32,7 +33,7 @@ module.exports = ({ markdownAST, pathPrefix }, pluginOptions = {}) => {
                 const image = {
                     type: 'image',
                     title: 'remark-draw image',
-                    url: path.join('/', pathPrefix, fileName)
+                    url: urljoin('/', pathPrefix, fileName)
                 };
               
                 parent.children.splice(index, 1, image);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "license": "MIT",
   "dependencies": {
     "skyrta": "^0.1.8",
-    "unist-util-visit": "^1.3.0"
+    "unist-util-visit": "^1.3.0",
+    "url-join": "^4.0.0"
   },
   "bugs": {
     "url": "https://github.com/rhanekom/gatsby-remark-draw/issues"


### PR DESCRIPTION
path.join uses the platform path separator, which is \ on Windows - this results in a URL to the image starting with a \ on Windows, which isn't correct.

Fixes #1.