### PR TITLE
Compatibility with gatsby-plugin-mdx

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,4 +48,6 @@ module.exports = ({ markdownAST, pathPrefix }, pluginOptions = {}) => {
             console.error(`Unhandled exception in rendering: ${e}`);            
         }
     });
+
+    return markdownAST;
 };


### PR DESCRIPTION
`gatsby-plugin-mdx` doesn't seem to work with `gatsby-remark-draw` because it does not return the `markdownAST` after processing, causing the code block to be rendered as a mere code block.